### PR TITLE
fix return type of call operator in function.rst

### DIFF
--- a/docs/source/api/function.rst
+++ b/docs/source/api/function.rst
@@ -73,7 +73,7 @@ This makes it much easier to work with multiple return values. Using ``std::tie`
 	:caption: function: call operator / function call
 
 	template<typename... Args>
-	protected_function_result operator()( Args&&... args );
+	function_result operator()( Args&&... args );
 
 	template<typename... Ret, typename... Args>
 	decltype(auto) call( Args&&... args );


### PR DESCRIPTION
without result type specification it returns `function_result`